### PR TITLE
Add prettier to ESLint config for auto formatting

### DIFF
--- a/.eslintrc.yml
+++ b/.eslintrc.yml
@@ -6,13 +6,19 @@ env:
 
 extends:
   - eslint:recommended
+  - prettier
 
 globals:
   Elm: false
 
+plugins:
+  - prettier
+
 root: true
 
 rules:
+  prettier/prettier: [warn, {printWidth: 80, singleQuote: true}]
+
   eqeqeq: error
   indent: [warn, 2]
   no-console: warn

--- a/encryption.js
+++ b/encryption.js
@@ -10,29 +10,26 @@ function generateKey(passphrase, appWiseSalt) {
   const passphraseKey = encoder.encode(passphrase);
   const salt = encoder.encode(atob(appWiseSalt));
 
-  return crypto.subtle.importKey(
-    'raw',
-    passphraseKey,
-    'PBKDF2',
-    false,
-    ['deriveKey']
-  ).then(key => {
-    return crypto.subtle.deriveKey(
-      {
-        name: 'PBKDF2',
-        salt: salt,
-        iterations: 1000,
-        hash: 'sha-256'
-      },
-      key,
-      {name: 'AES-GCM', length: 256},
-      true,
-      ['encrypt', 'decrypt']);
-  });
+  return crypto.subtle
+    .importKey('raw', passphraseKey, 'PBKDF2', false, ['deriveKey'])
+    .then(key => {
+      return crypto.subtle.deriveKey(
+        {
+          name: 'PBKDF2',
+          salt: salt,
+          iterations: 1000,
+          hash: 'sha-256'
+        },
+        key,
+        { name: 'AES-GCM', length: 256 },
+        true,
+        ['encrypt', 'decrypt']
+      );
+    });
 }
 
 function base64ToArrayBuffer(base64) {
-  const binary_string =  window.atob(base64);
+  const binary_string = window.atob(base64);
   const len = binary_string.length;
   const bytes = new Uint8Array(len);
   for (let i = 0; i < len; i++) {
@@ -45,7 +42,7 @@ function arrayBufferToBase64(bytes) {
   let binary = '';
   const len = bytes.byteLength;
   for (let i = 0; i < len; i++) {
-    binary += String.fromCharCode(bytes[ i ]);
+    binary += String.fromCharCode(bytes[i]);
   }
   return window.btoa(binary);
 }
@@ -79,10 +76,14 @@ function encrypt(passphrase, content) {
           iv: initVector
         },
         encryptionKey,
-        data);
+        data
+      );
     })
     .then(encryptedData => {
-      const encryptedContent = joinIvAndData(initVector, new Uint8Array(encryptedData));
+      const encryptedContent = joinIvAndData(
+        initVector,
+        new Uint8Array(encryptedData)
+      );
       const encrypted = arrayBufferToBase64(encryptedContent);
       console.log(encrypted);
       return encrypted;
@@ -126,7 +127,8 @@ function decrypt(passphrase, encryptedContent) {
           iv: parts.iv
         },
         decryptionKey,
-        parts.data);
+        parts.data
+      );
     })
     .then(decryptedArrayBuffer => {
       const decrypted = decoder.decode(decryptedArrayBuffer);

--- a/manifest.json
+++ b/manifest.json
@@ -4,7 +4,7 @@
   "name": "Hoverpad",
   "version": "1.7",
 
-  "description": "Allows the user to make quick notes by clicking a button and entering text into the resulting popup. The notes are saved in storage and sync across profiles. See https://developer.mozilla.org/en-US/Add-ons/WebExtensions/Examples#hoverpad",
+  "description": "Allows the user to make quick notes by clicking a button and entering text into the resulting popup. The notes are saved in storage and sync across profiles. See https://developer.mozilla.org/Add-ons/WebExtensions/Examples#hoverpad",
   "icons": {
     "48": "icons/hoverpad-48.png"
   },

--- a/package.json
+++ b/package.json
@@ -1,10 +1,11 @@
 {
-  "name": "Hoverpad",
+  "name": "hoverpad",
   "version": "1.7.0",
-  "description": "Hoverpad",
+  "description": "Allows the user to make quick notes by clicking a button and entering text into the resulting popup. The notes are saved in storage and sync across profiles. See https://developer.mozilla.org/Add-ons/WebExtensions/Examples#hoverpad",
   "scripts": {
     "build": "rm -fr web-ext-artifacts/ && elm-make Main.elm --output=www/hoverpad.js && cp -r manifest.json *.js *.css icons index.html www/",
     "debug": "elm-live Main.elm --output=hoverpad.js --open -- --debug",
+    "format": "npm run lint -- --fix",
     "lint": "eslint .",
     "live": "elm-live Main.elm --output=hoverpad.js --open",
     "fx-web-ext": "npm run build && web-ext build -s www && unzip -l web-ext-artifacts/*.zip",
@@ -32,6 +33,8 @@
     "elm": "^0.18.0",
     "elm-live": "^2.6.1",
     "eslint": "^3.16.1",
+    "eslint-config-prettier": "^1.4.0",
+    "eslint-plugin-prettier": "^2.0.1",
     "gh-pages": "^0.11.0",
     "web-ext": "^1.7.0"
   }

--- a/ports.js
+++ b/ports.js
@@ -2,7 +2,7 @@
 /* globals encrypt:false, decrypt:false */
 
 let app;
-if (typeof(Elm) === 'undefined') {
+if (typeof Elm === 'undefined') {
   // This happens if we're in the context of Electron.
   const Elm = require('./hoverpad.js');
   app = Elm.Main.fullscreen();


### PR DESCRIPTION
Added [**prettier**](https://github.com/prettier/prettier) and hooked it up to the ESLint config so we can use .eslintignore and the ESLint file globs. Plus lets us autoformat using `$ eslint . --fix` (via `$ npm run format`)